### PR TITLE
Eliminates defaults channel from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: stmod
 channels:
   - conda-forge
   #- http://ssb.stsci.edu/astroconda
-  - defaults
+  #- defaults
 dependencies:
   - python=3.11
   - numpy


### PR DESCRIPTION
The "defaults" channel needs to be eliminated from environment.yml as it is no longer supported on MPE SciServer